### PR TITLE
fixed npm run dev issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "email": ""
   },
   "scripts": {
-    "predev": "vuepress check-md docs",
-    "dev": "vuepress dev docs",
-    "prebuild": "vuepress check-md docs",
-    "build": "vuepress build docs",
+    "predev": "export NODE_OPTIONS=--openssl-legacy-provider && vuepress check-md docs",
+    "dev": "export NODE_OPTIONS=--openssl-legacy-provider && vuepress dev docs",
+    "prebuild": "export NODE_OPTIONS=--openssl-legacy-provider && vuepress check-md docs",
+    "build": "export NODE_OPTIONS=--openssl-legacy-provider && vuepress build docs",
     "postbuild": "sh check-links.sh"
   },
   "license": "MIT",


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/docs-apk/issues/26


**If you are running the APK docs locally on a Windows OS, uncomment this section.**
```
  "scripts": {
    "predev": "set NODE_OPTIONS=--openssl-legacy-provider && vuepress check-md docs",
    "dev": "set NODE_OPTIONS=--openssl-legacy-provider && vuepress dev docs",
    "prebuild": "set NODE_OPTIONS=--openssl-legacy-provider && vuepress check-md docs",
    "build": "set NODE_OPTIONS=--openssl-legacy-provider && vuepress build docs",
    "postbuild": "sh check-links.sh"
  }, 
```


**If you are running the APK docs locally on a Ubuntu/Mac OS, uncomment this section.**

```
  "scripts": {
    "predev": "export NODE_OPTIONS=--openssl-legacy-provider && vuepress check-md docs",
    "dev": "export NODE_OPTIONS=--openssl-legacy-provider && vuepress dev docs",
    "prebuild": "export NODE_OPTIONS=--openssl-legacy-provider && vuepress check-md docs",
    "build": "export NODE_OPTIONS=--openssl-legacy-provider && vuepress build docs",
    "postbuild": "sh check-links.sh"
  },
```

The Ubuntu/Mac OS related code fix has been added to the docs.