### PR TITLE
Updating custom-filters doc location

### DIFF
--- a/en/docs/setup/customizations/gateway-enforcer/mediation-extensions/custom-filters.md
+++ b/en/docs/setup/customizations/gateway-enforcer/mediation-extensions/custom-filters.md
@@ -1,4 +1,4 @@
-# Add Custom Filters in the Enforcer
+# Add Custom Filters to Execute at the Global Level
 
 Filters is a set of execution points in the request flow that intercept the request before it goes to the backend service. They are engaged while the request is processed within the Enforcer. The defined set of filters are applied to all the APIs deployed in the Gateway. These filters are engaged inline and if the request fails at a certain filter, the request will not be forwarded to the next filter and the backend. The inbuilt set of filters are the authentication filter and the throttling filter.
 

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -118,14 +118,13 @@ nav:
        #    - Key Concept 2: about-apk/key-concepts/key-concept.md
         - WSO2 APK Deck:
             #- APK Deck Overview: apk-deck/overview.md
-            - API Gateway:
+            #- API Gateway:
                #- API Gateway - Router:
                #    - Router - Overview: apk-deck/router-overview.md
                #    - Topic 1: get-started/dummy.md
                #    - Topic 2: get-started/dummy.md
-                - API Gateway - Enforcer:
+                #- API Gateway - Enforcer:
                 #    - Enforcer - Overview: apk-deck/enforcer-overview.md
-                   - Custom Filters: apk-deck/gateway/enforcer/custom-filters.md
                 #   - Topic 2: get-started/dummy.md
             - Identity Platform:
                 IdP:
@@ -170,10 +169,11 @@ nav:
        #        - Deployment Pattern 2: get-started/dummy.md
        #        - Deployment Pattern 3: get-started/dummy.md
        #- CI/CD: develop-and-deploy-api/ci-cd.md
-       #- Customizations:
-       #    - Gateway: 
-       #        - Customization 1: setup/gateway-customizations.md
-       #        - Customization 2: setup/gateway-customizations.md
+        - Customizations:
+            - API Gateway - Enforcer:
+            #    - Enforcer - Overview: apk-deck/enforcer-overview.md
+                - Mediation Extensions:
+                    - Custom Filters: setup/customizations/gateway-enforcer/mediation-extensions/custom-filters.md
     - Administration:
         - Organizations: administration/organizations.md
         - Test System APIs: administration/postman-tests.md


### PR DESCRIPTION
## Purpose
- Changing location of `custom-filters.md` to [2] based on feedback from Sanjeewa and Amali.

[2] setup/customizations/gateway-enforcer/mediation-extensions/custom-filters.md


![Custom-Filters-APK-Documentation-1-0-0 (1)](https://user-images.githubusercontent.com/5195851/224289831-6587652b-d8c3-4e16-93dd-e9f6e9937b91.png)

### Related to
https://github.com/wso2/docs-apk/issues/43

