### PR TITLE
Fixing the tab issue in the getting started page

### DIFF
--- a/en/docs/includes/start-apk.md
+++ b/en/docs/includes/start-apk.md
@@ -7,15 +7,15 @@ Follow the instructions below to deploy APK Data Service (DS) servers and the Cl
 
 3.  Install the APK components and start WSO2 API Platform For Kubernetes.
 
-   	=== "Format"
+	=== "Format"
 		```
 		helm install <chart-name> <repository-name>/apk-helm --version <verison-of-APK> -n <namespace>
 		```
-
-
+	
 	=== "Command"
 		```
 		helm install apk_test wso2apk/apk-helm --version 0.0.1-m10 -n apk
+		```
 
 	!!! info "Optional"
 

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -37,7 +37,6 @@ theme:
     logo: images/logo-for-light.svg
     favicon: images/favicon.png
     features:
-        - content.tabs.link
         - content.code.copy
         - navigation.tabs
         - navigation.tabs.sticky


### PR DESCRIPTION
Fixing the tab issue in the getting started page and removing persisting tab selection cross pages feature from mkdocs