### PR TITLE
Add docs for BackendJWT policy configuration via REST API

### DIFF
--- a/en/docs/create-api/create-and-attach-api-policies/backend-jwt-token-manipulation/backend-jwt-token-manipulation-via-rest-api.md
+++ b/en/docs/create-api/create-and-attach-api-policies/backend-jwt-token-manipulation/backend-jwt-token-manipulation-via-rest-api.md
@@ -1,0 +1,81 @@
+# Attach Backend JWT Token manpulation Policy to APIs via REST API
+
+There can be scenarios where a backend service needs to make different decisions or respond with different data, depending on the application end-user that consumes an API. This can be facilitated by APK by sending the attributes in a JWT via an HTTP header, to the backend service when the API call is being forwarded.
+
+To find more information about backend JWT generation, please refer to the [Passing End User Attributes to the Backend](https://apim.docs.wso2.com/en/latest/deploy-and-publish/deploy-on-gateway/choreo-connect/passing-enduser-attributes-to-the-backend-via-choreo-connect/#enabling-the-default-backend-jwt-generator).
+
+## Before you begin
+
+- [Create an API](../../get-started/quick-start-guide.md)
+
+### Backend JWT configuration
+
+<table>
+    <tbody>
+        <tr>
+            <th colspan="2">Field</th>
+            <th>Description</th>
+        </tr>
+        <tr>
+            <td colspan="2" class="confluenceTd"><pre>enabled</pre></td>
+            <td class="confluenceTd">Set this value to <code>true</code> to enable Backend JWT.</td>
+        </tr>
+        <tr>
+            <td colspan="2" class="confluenceTd"><pre>encoding</pre></td>
+            <td class="confluenceTd">The encoding mechanism used to encode the Backend JWT.</td>
+        </tr>
+        <tr>
+            <td colspan="2" class="confluenceTd"><pre>signingAlgorithm</pre></td>
+            <td class="confluenceTd">The signing algorithm used to sign the Backend JWT.</td>
+        </tr>
+        <tr>
+            <td colspan="2" class="confluenceTd"><pre>header</pre></td>
+            <td class="confluenceTd">The name of the HTTP header to which the Backend JWT is attached.</td>
+        </tr>
+        <tr>
+            <td colspan="2" class="confluenceTd"><pre>tokenTTL</pre></td>
+            <td class="confluenceTd">The expiry time of the Backend JWT.</td>
+        </tr>
+        <tr>
+            <td colspan="2" class="confluenceTd"><pre>customClaims</pre></td>
+            <td class="confluenceTd">List of custom claims that needs to be added to the Backend JWT.</td>
+        </tr>
+    </tbody>
+</table>
+
+
+   Sample APK configuration content after the modification is shown below.
+
+   ```
+   name: "test-backend-jwt"
+   context: "/backend_jwt"
+   version: "1.0.0"
+   type: "REST"
+   organization: "apk-org"
+   defaultVersion: false
+   endpointConfigurations:
+     production:
+       endpoint: "https://httpbin.org/anything"
+   operations:
+       - target: "/test"
+         verb: "GET"
+         authTypeEnabled: true
+         scopes: []
+   vhosts:
+     production: ["default.gw.wso2.com"]
+   apiPolicies:
+     request:
+       - policyName: "BackendJwt"
+         parameters:
+           enabled: true
+           encoding: base64
+           signingAlgorithm: SHA256withRSA
+           header: X-JWT-Assertion
+           tokenTTL: 3600
+           customClaims:
+           - claim: claim1
+             value: value1
+           - claim: claim2
+             value: value2
+
+   ```

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
                 - Query manipulation: 
                     - Overview: create-api/create-and-attach-api-policies/query-manipulation/query-manipulation-overview.md
                 - Backend JWT Token Manipulation:
+                    - Via REST API: create-api/create-and-attach-api-policies/backend-jwt-token-manipulation/backend-jwt-token-manipulation-via-rest-api.md
                     - Via CR: create-api/create-and-attach-api-policies/backend-jwt-token-manipulation/backend-jwt-token-manipulation-via-crs.md
                 - CORS:
                     - Via REST API: create-api/create-and-attach-api-policies/cors/enable-cors-via-rest-api.md


### PR DESCRIPTION
## Purpose
Add docs for BackendJWT policy configuration via REST API

![Screenshot 2023-07-25 at 15-14-58 Via REST API - APK Documentation 1 0 0](https://github.com/wso2/docs-apk/assets/18748929/4a03c9b1-37d8-4aa9-a9d0-bdc2021351d2)
