### PR TITLE
[1.0.0] Update copyrights

### DIFF
--- a/en/theme/material/partials/copyright.html
+++ b/en/theme/material/partials/copyright.html
@@ -17,7 +17,7 @@
   </div>
   <div class="footer-copyright-right">
     <div class="footer-copyright-top">
-      Copyright &copy; <a href="https://wso2.com/">WSO2</a> LLC 2023
+      Copyright &copy; <a href="https://wso2.com/">WSO2</a> LLC (2023-2024)
     </div>
     <div class="footer-copyright-bottom">
       Content licensed under <a href="https://creativecommons.org/licenses/by/4.0">CC By 4.0.</a> | Sample code


### PR DESCRIPTION
## Purpose
fixes https://github.com/wso2/docs-apk/issues/397
Updated the year mentioned in the copyrights statement.
- WSO2 generally follows the standard of adding the year of the copyrights based on the initial year the documentation was created to the current year (e.g., [1]). Therefore, I updated the copyrights year in this manner as opposed to just mentioning 2024.

[1] https://is.docs.wso2.com/en/5.11.0/


## Related issue
https://github.com/wso2/docs-apk/issues/397

## Assignee
@Mariangela 

## Labels
OpenSourceContribution