### PR TITLE
Changing K8s version in pre-requisite and fixing links in QSG CP Docs

### DIFF
--- a/en/docs/control-plane/apk-as-gateway-in-apim/apk-as-gateway-in-apim-qsg.md
+++ b/en/docs/control-plane/apk-as-gateway-in-apim/apk-as-gateway-in-apim-qsg.md
@@ -128,11 +128,11 @@ Now you can verify the deployment by executing the following command. You will s
 
 ### Create Deploy and Publish the API
 
-{!control-plane/api-management/control-plane-create-and-deploy-rest-apis.md!}
+{!control-plane/apk-as-gateway-in-apim/api-management/control-plane-create-and-deploy-rest-apis.md!}
 
 ### Create Application and Subscribe to the API
 
-{!control-plane/api-management/control-plane-create-application-and-subscription.md!}
+{!control-plane/apk-as-gateway-in-apim/api-management/control-plane-create-application-and-subscription.md!}
 
 
 ## Step 3 - Invoke the API

--- a/en/docs/setup/prerequisites.md
+++ b/en/docs/setup/prerequisites.md
@@ -39,23 +39,23 @@ Here are the minimum resource requirements for the Kubernetes cluster to run APK
 
 Here are the supported manage Kubernetes services:
 
-| Platform     | Cluster Version          |
-|--------------|------------------|
-| EKS          | 1.27             |
-| GKE          | 1.27.3           |
-| AKS          | 1.27             |
+| Platform     | Cluster Version |
+|--------------|-----------------|
+| EKS          | 1.27 - 1.29.4   |
+| GKE          | 1.27.3 - 1.29.4 |
+| AKS          | 1.27   - 1.29.4 |
 
 
 ### Kubernetes Distributions
 
 Here are the supported Kubernetes distributions:
 
-| Software Application | Cluster Version  |  Software Version |
-|----------------------|------------------|-------------------|
-| Minikube             |  1.26.3 - 1.27.4 | 1.30.1 - 1.31.1   |
-| Rancher              |  1.27.2          |     1.9.1         |
-| Kind                 |  1.26.3          |     1.25.3        |
-| Openshift            |  4.13.3          |  2.23.0+ddcfe8    | 
+| Software Application | Cluster Version | Software Version |
+|----------------------|----------------|------------------|
+| Minikube             | 1.26.3 - 1.29.4 | 1.30.1 - 1.31.1  |
+| Rancher              | 1.27.2 - 1.29.4 | 1.9.1 - 1.13.1   |
+| Kind                 | 1.26.3 - 1.29.4 | 1.25.3           |
+| Openshift            | 4.13.3         | 2.23.0+ddcfe8    | 
 
 ### Other Dependencies
 


### PR DESCRIPTION
## Purpose
Changing K8s version in pre-requisite and fixing links in QSG CP Docs