### PR TITLE
Updating deployment guides for REST, GraphQL, AI API and gRPC

### DIFF
--- a/en/docs/create-api/create-and-deploy-apis/ai/create-ai-api-using-rest-api.md
+++ b/en/docs/create-api/create-and-deploy-apis/ai/create-ai-api-using-rest-api.md
@@ -26,13 +26,13 @@ For this use case, we will use the Azure OpenAI service and will use the API Key
 
 This service generates an APK configuration file by providing your OAS file. APK configuration file includes important API metadata, rate limiting details, security settings, and other necessary information about your API.
 
-The OpenAPI specification file can be provided as a local file or as a URL containing a definition file. For this use case, we will use the Azure OpenAI OAS definition therefore download and save the azure OAS file as <b>azure_api.yaml</b>.
+The OpenAPI specification file can be provided as a local file or as a URL containing a definition file. For this use case, we will use the Azure OpenAI OAS definition therefore download and save the azure OAS file as <b>azure-api.yaml</b>.
 
 === "Sample Request"
     ```
-    curl -k --location 'https://api.am.wso2.com:9095/api/configurator/1.3.0/apis/generate-configuration' \
-    --header 'Host: api.am.wso2.com' \
-    --form 'definition=@"/Users/user/azure_api.yaml"'
+    curl -k --location 'https://api.example.com:9095/api/configurator/1.3.0/apis/generate-configuration' \
+    --header 'Host: api.example.com' \
+    --form 'definition=@"/Users/user/azure-api.yaml"'
     ```
 === "Request Format"
     ```
@@ -43,7 +43,7 @@ The OpenAPI specification file can be provided as a local file or as a URL conta
 === "Sample Response"
     ```yaml
     name: "Azure OpenAI Service API"
-    basePath: "/QXp1cmUgT3BlbkFJIFNlcnZpY2UgQVBJMjAyNC0wNi0wMQ"
+    basePath: "/azure-open-ai"
     version: "2024-06-01"
     type: "REST"
     defaultVersion: false
@@ -78,7 +78,7 @@ The OpenAPI specification file can be provided as a local file or as a URL conta
       scopes: []
     ```
 
-You will get the apk-conf file content as the response, as seen in the above sample response. Save this content into a file with the `.apk-conf` file extension. For example, you can save under the name, azure.apk-conf. 
+You will get the apk-conf file content as the response, as seen in the above sample response. Save this content into a file with the `.apk-conf` file extension. For example, you can save under the name <b>azure.apk-conf</b>. 
 
 !!! note 
     You will need to fill in the AI Provider and Endpoint Configuration fields such as endpoint and security, before deploying the API.
@@ -87,18 +87,18 @@ You will get the apk-conf file content as the response, as seen in the above sam
 
 Review the content inside the apk-conf file and update it with additional API configurations as needed, such as configuring AI Provider, LLM Service URl in the Endpoint Configuration, Secret which stores the API key provided from LLM Service and rate limits, CORS configurations, etc.
 
-Refer to the sample configuration file below:
+Refer to the sample configuration file below. For this guide, replace the contents of the apk-conf file that you generated with the contents of this sample configuration and replace the `{endpoint}` and `{deployment-id}` in the endpoint field with the actual values provided by the LLM Service Provider.
 
 ```yaml
 name: "Azure OpenAI Service API"
-basePath: "/QXp1cmUgT3BlbkFJIFNlcnZpY2UgQVBJMjAyNC0wNi0wMQ"
+basePath: "/azure-open-ai"
 version: "1.0.0"
 type: "REST"
 defaultVersion: false
 subscriptionValidation: false
 aiProvider:
   name: "AzureAI"
-  apiVersion: "2021-06-01"
+  apiVersion: "2024-06-01"
 endpointConfigurations:
   production:
     - endpoint: "https://{endpoint}/openai/deployments/{deployment-id}"
@@ -174,11 +174,11 @@ Create a secret containing the API Key of the LLM Service Provider using the fol
 
 === "Sample Command"
     ```bash
-        kubectl create secret generic azure-ai-secret --from-literal=apiKey='xxxxxxxxxxxxxxxxxxx' 
+    kubectl create secret generic azure-ai-secret --from-literal=apiKey='xxxxxxxxxxxxxxxxxxx' 
     ```
 === "Command Format"
     ```bash
-        kubectl create secret generic azure-ai-secret --from-literal=apiKey='<<api key of LLM Service>>' --namespace=<<namespace>>
+    kubectl create secret generic azure-ai-secret --from-literal=apiKey='<<api key of LLM Service>>' --namespace=<<namespace>>
     ```
 
 ## Step 6. Deploy the API to a Kubernetes cluster.
@@ -193,7 +193,7 @@ After generating the token, you can deploy the API directly into APK using API S
 
 === "Sample Request"
     ```
-    curl -k --location 'https://api.am.wso2.com:9095/api/deployer/1.3.0/apis/deploy' \
+    curl -k --location 'https://api.example.com:9095/api/deployer/1.3.0/apis/deploy' \
     --header 'Content-Type: multipart/form-data' \
     --header 'Accept: application/yaml' \
     --header 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiZ2F0ZXdheV9jZXJ0aWZpY2F0ZV9hbGlhcyJ9.eyJpc3MiOiJodHRwczovL2lkcC5hbS53c28yLmNvbS90b2tlbiIsICJzdWIiOiI0NWYxYzVjOC1hOTJlLTExZWQtYWZhMS0wMjQyYWMxMjAwMDIiLCAiYXVkIjoiYXVkMSIsICJleHAiOjE3MzAwMTQ0MjksICJuYmYiOjE3MzAwMTA4MjksICJpYXQiOjE3MzAwMTA4MjksICJqdGkiOiIwMWVmOTQyZC02Y2I0LTFjNDgtYmFmYS04Yzg5NGFlZWZkYzIiLCAiY2xpZW50SWQiOiI0NWYxYzVjOC1hOTJlLTExZWQtYWZhMS0wMjQyYWMxMjAwMDIiLCAic2NvcGUiOiJhcGs6YXBpX2NyZWF0ZSJ9.isgFKKbdmIApTpCcZEhn1aWpHPFs4ZRhEva9Hjj6WMQWtwlYYlcgBK_g08p1zA0HOxCOZuAsXBcEMLnJ9HzgBq0bWKegWwAt_oTHCvDu4yi4gNYR0TLPc_8goa6fXS-iLckrG22Csi7ODoj84agW6rwLEq4G62dVWt4dNMSSO91cy2HdYtVjcnbKxefVJ942uwJOqqL4HqDc4a-u1rHeLchvwn_b1ezZIyWHcZQFsY2PP3UBZ30t_5-08V3w2AbkVXvppYpHKNqg647MzdOChz66nF0va5FxmlTr71uY0Q4Gufv-tT6QENWX_GcYhDmdH4OQXTFt9jHgm8lcXxyK7g' \
@@ -212,7 +212,7 @@ After generating the token, you can deploy the API directly into APK using API S
     ```
     id: "8bcdea77634e2d4c827a7ea88f8075c4dd538834"
     name: "Azure OpenAI Service API"
-    basePath: "/QXp1cmUgT3BlbkFJIFNlcnZpY2UgQVBJMjAyNC0wNi0wMQ"
+    basePath: "/azure-open-ai"
     version: "1.0.0"
     type: "REST"
     defaultVersion: false
@@ -272,7 +272,7 @@ After generating the token, you can deploy the API directly into APK using API S
 You can generate K8s resources as a zip file from config-deployer service.
 
 ```
-curl --location 'https://api.am.wso2.com:9095/api/configurator/1.3.0/apis/generate-k8s-resources' \
+curl --location 'https://api.example.com:9095/api/configurator/1.3.0/apis/generate-k8s-resources' \
 --header 'Content-Type: multipart/form-data' \
 --header 'Accept: application/zip' \
 --form 'apkConfiguration=@"/Users/user/azure.apk-conf"' \
@@ -292,7 +292,7 @@ kubectl apply -f <path_to_extracted_zip_file>
 
 === "Sample Request"
     ```
-    curl -X POST "https://default.gw.wso2.com:9095/QXp1cmUgT3BlbkFJIFNlcnZpY2UgQVBJMjAyNC0wNi0wMQ/1.0.0/chat/completions?api-version=2024-06-01" \
+    curl -X POST "https://default.gw.example.com:9095/azure-open-ai/1.0.0/chat/completions?api-version=2024-06-01" \
       -H "Content-Type: application/json" \
       -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiZ2F0ZXdheV9jZXJ0aWZpY2F0ZV9hbGlhcyJ9.eyJpc3MiOiJodHRwczovL2lkcC5hbS53c28yLmNvbS90b2tlbiIsICJzdWIiOiI0NWYxYzVjOC1hOTJlLTExZWQtYWZhMS0wMjQyYWMxMjAwMDIiLCAiYXVkIjoiYXVkMSIsICJleHAiOjE3MzAwMTU0NDIsICJuYmYiOjE3MzAwMTE4NDIsICJpYXQiOjE3MzAwMTE4NDIsICJqdGkiOiIwMWVmOTQyZi1jODgwLTE0ZDYtYTMzNC0yNTMyMDEzNzhkOWUiLCAiY2xpZW50SWQiOiI0NWYxYzVjOC1hOTJlLTExZWQtYWZhMS0wMjQyYWMxMjAwMDIiLCAic2NvcGUiOiJhcGs6YXBpX2NyZWF0ZSJ9.Lumx8tBDTNhwgfUHWwgiSQEwcjz6ZF-5f3UJfJlCNv7feAnIEsdGmb5sFw6wRQBZklSVsZYffj1uK7ManfSR6gfws-W1qo5itwYFixvkoOMU5HcxtVdTsYOl8CzN4u76hbbk_r7I3vov-2g4iMT2Lfu45g1u1sEj1JgjbpOnTZdZ2c2jWHal35idLSEBhULMElGPjce1uCwTS2zsEZQond1q3HvMouIJ58q2oGaD4qpcx-FTlbYKsBD5_h4v4U2PV3kGkxLzos4eXoeM88vbVhIew-z8NxZuxiuP3dS4AAIbHevkQgmueMdN6E0Y5xXoYbcTDVuB8dMYAuctof6b4A' \
       -d '{

--- a/en/docs/create-api/create-and-deploy-apis/graphql/create-graphql-api-using-crs.md
+++ b/en/docs/create-api/create-and-deploy-apis/graphql/create-graphql-api-using-crs.md
@@ -1,7 +1,8 @@
-Similar to the approach for <a href="../../rest/create-rest-api-using-crs" target="_blank">REST APIs</a>, this approach requires three CRs.
+This approach requires four CRs.
 
 - API CR
 - GQLRoute CR
+- ConfigMap CR
 - Backend CR
 
 For this guide, you can create a sample backend for the GraphQL API using the following command.
@@ -9,15 +10,15 @@ For this guide, you can create a sample backend for the GraphQL API using the fo
 kubectl apply -f https://raw.githubusercontent.com/wso2/apk/main/developer/tryout/samples/gql-sample-backend.yaml -n <namespace>
 ```
 
-The GraphQL definition file used for this guide is available at <a href="https://raw.githubusercontent.com/wso2/apk/main/developer/tryout/samples/definitions/StarWars.graphql" target="_blank">https://raw.githubusercontent.com/wso2/apk/main/developer/tryout/samples/definitions/StarWars.graphql</a>.
+The GraphQL definition file used for this guide can be found here: <a href="https://raw.githubusercontent.com/wso2/apk/main/developer/tryout/samples/definitions/StarWars.graphql" target="_blank">StarWars.graphql</a>
 
-#### API CR 
+### API CR 
 
-In the following CR, we have defined the GraphQL API giving the name, context, and version information for the API. We have also referred to `GQLRoute` resource in `spec.production.routeRefs[0]` path which we create in the next step.
+In the following CR, we have defined the GraphQL API giving the name, context, and version information for the API. We have also referred to `GQLRoute` resource in `spec.production.routeRefs[0]` path as well as `ConfigMap` resource in `spec.definitionFileRef` which we create in the next steps.
 
 ```yaml
 kind: "API"
-apiVersion: "dp.wso2.com/v1alpha2"
+apiVersion: "dp.wso2.com/v1alpha3"
 metadata:
   name: "starwars-api"
 spec:
@@ -26,13 +27,14 @@ spec:
   apiVersion: "1.0.0"
   basePath: "/starwars/1.0.0"
   isDefaultVersion: false
+  definitionFileRef: "gql-definition"
   organization: default
   production:
   - routeRefs:
     - "production-gqlroute-1"
 ```
 
-#### GQLRoute CR 
+### GQLRoute CR 
 
 This is the resource where you define resources of your API. This `GQLRoute` is linked to the API by referring to this resource name from the `API` resource. This example only exposes some of the operations defined in the Star Wars SDL provided earlier.
 
@@ -43,7 +45,7 @@ metadata:
   name: "production-gqlroute-1"
 spec:
   hostnames:
-  - "wso2-apk-default.gw.wso2.com"
+  - "default.gw.example.com"
   rules:
   - matches:
     - path: hero
@@ -79,12 +81,26 @@ spec:
     sectionName: "httpslistener"
 ```
 
-#### Backend CR 
+### ConfiMap CR
+
+This resource contains the definition for the API found in <a href="https://raw.githubusercontent.com/wso2/apk/main/developer/tryout/samples/definitions/StarWars.graphql" target="_blank">StarWars.graphql</a> encoded in `Base64` format.
+
+```yaml
+kind: "ConfigMap"
+apiVersion: "v1"
+metadata:
+  name: "gql-definition"
+binaryData:
+  definition: "H4sIAAAAAAAA/8VYWW/cNhB+318xRh7qApvAaRGkXaAPjr2GFdRHbbd5CIyClmZXrCVSpSivF0n/e2eG1LGHr4cgL16RHM75zUHXaY6lgi8jgH8bdMsJ/ME/tCwbr7y2ZgIn8Ys26+amTp2uwsHlYDX6bzR6BVc5Bj7glxWOwWHlsEbja1BFAXYGnihoTRSV1bxPfyzYxoG9+QdTD3OnqnzE14MqoluOzu5ipWub4QSm4ePHCRzkyqnUoyMah3caF/UG2Q7Rfb6Qw2s2AZVL812P954s8E6bORNcyvYF1k3hmSxtOe/qbALJ4c6atMxZnQ3ODnnNmjalMoP9Y17TPpkvn/XuTLuaRCfGs1zZvA4EwmOdQDYjQafAOlF3IBZ65epcVwMtLuNWH6U2vNsD1VSZ8ljDAiFVBkp1ixDDRAcqhKfFhUQodUg3gps3QjCOwZlAIEhM1XjWKyx7rYb42q7ZkOIJ/YbwFB2DEvtZhtk2MK0rE0kYogJbdiJ8IkcCoaaw8+UITVO2DETCqwFRu5/8NYF9OMUFHNtgUIGqxozZvv31/fs3dO90+un47Hw6eoAFcWCFpmWlHQpob0mtDyq9XWf3yx6zm56cJxcPc0vYVt840ybkR8z0BqefmdPH6WHyEJ8kEUZ3aObYcrrUPl/l9NPe3jticJlcHQfX7ve5BTNnyzXfNkbfEcBxRIUB3Uyl2Odd9DH7IjlsRaaDrIyIH3VkRpW4jZD32/QfkM+cRpPVGzfGYB0Q0LCs/BIKXXvQQrKEXN2RGGuQmMTrqwn5JHPA+8qytxRBHFJrDNVBxuyCnAmYzbHueR90x4MSMAY1I0ZsO+H4aJ1yYGBpCeME4FzXAwVUVSH7XkulCouECvznGOrrnRC6P432on+Oep77gP/fKf4+56NBeKgGmUy5jMPpQTnbmEysXlhXcJ08mV5NL4Je506XijJqCU3EDBMyQ1oRMLzYf3R2dtUCSIoslcVQdRqHjwJJioHUWdBlVWApxeRxUOWxbK8A6lOufHCdHFPpKQr2JZY1Fnei5QO4yi3BsCqUQb8iQXBlGqprBKfG3Bq7YKlMfi7ULa/A6ljc3nqI6uIMncPg5DFkOFPUvYD0K5GbhDROvrHLBJNhpH4LAWC0FFb5wP5E1VLsbrm6OVXWD6hXEt3KxavOJz/ULVC/RcoEt3+ndAnCn5Eqcns/mEyKt+04sqkoMKRsTtpX5GfC+HZPRf90t3lGid/XMQ9Im8ZbY0vbcMgpn40mTA4Se6NzrSaFzBbPT4oszjibSWHpmLhzQgQrW9Kt+dCef1uwiIjvBZYg/LlgWXFJJeVwCbPGpHHsjltHcacrCm0/7c2KQ/SM3dnjoHd0iPuGFYNwe+sJQlTYbwgF5Mr2IoSTA6rkwTG94eJGkYkqzTf6Wy+dJwohJhdEHaa0vF5PGd9Hc9xFjuYM2qFxYJGjiTKVY2x4MIg01L15FCKJIQ3LMLGyrpWaa0NLM4/tsPMGe1zNkS9M4Dx+7XRJx6Jf5mg2MrqYotVQAXCh1w31ELnhcG2I6fO5G4bp7s0y6B0FUl0QzTjpZLDtXyui+AvMF9Vbu0VvrkL+oNONw2iylTXVs1N6UvGtCXywlgZAE112MZjg4wwe/SYZE8SF4XuAw3AGsD6oD2a7DqNSJIMZkf+cqsYY3r5+15ZQgWz06YEtudyBurGNF7C1wtJwovghPMwxFqf50dLGnc0JQKypV1N14q4r0wg7VBEgF1GVUbg3ePhEI/devwuqvUBFqpPynFHFdmXl7pG6s46GJyIorFu5MotHf8sRYYR/RKkn7ayo6bNt1FJU4Bwt63nER1YWDQF6yyOabnVTNBgXJCw80WJH29pu2tb31Fw/oNvSbsLQs05LZaWwAn0E/kAqPOpecywKufCskSm11mWcRVLRPsv+zvWO9Ge6T5k2/LcCcQhT6NfYeL/27/L/AW5FtmOIEQAA"
+
+```
+
+### Backend CR 
 
 In the above created GQLRoute resource we have referred to a `Backend` resource in `spec.rules[0].backendRefs[0]` path. That `Backend` should be created as below:
 
 ```yaml
-apiVersion: "dp.wso2.com/v1alpha1"
+apiVersion: "dp.wso2.com/v1alpha2"
 kind: "Backend"
 metadata:
   name: "star-wars-api-backend"
@@ -113,4 +129,22 @@ Once you have designed your APIs using these essential CRs, the next step is to 
 
 ```
 kubectl apply -f <path_to_CR_files> -n <namespace>
+```
+
+## Invoking a GraphQL API
+
+Once your GraphQL API has been deployed, you can invoke it. The endpoint of the API would be /`<apk-gateway-host>`/`<api-basepath>`. 
+
+For the above API, the base path is `/starwars/1.0.0`, and if the gateway host is `default.gw.example.com` so the API URL would be 
+`/default.gw.example.com/starwars/1.0.0`.
+
+<a href="../../../../develop-and-deploy-api/security/generate-access-token" target="_blank">Generate an access token</a> and invoke the API using the sample GraphQL call is provided below.
+
+=== "Sample Request"
+```
+curl --location 'https://default.gw.example.com:9095/starwars/1.0.0' \
+--header 'Host: default.gw.example.com' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer <access-token>' \
+--data '{"query":"query hero ($episode: Episode) {\n    hero (episode: $episode) {\n        id\n        name\n        appearsIn\n    }\n}","variables":{"episode":"NEWHOPE"}}' -k
 ```

--- a/en/docs/create-api/create-and-deploy-apis/graphql/create-graphql-api-using-crs.md
+++ b/en/docs/create-api/create-and-deploy-apis/graphql/create-graphql-api-using-crs.md
@@ -81,7 +81,7 @@ spec:
     sectionName: "httpslistener"
 ```
 
-### ConfiMap CR
+### ConfigMap CR
 
 This resource contains the definition for the API found in <a href="https://raw.githubusercontent.com/wso2/apk/main/developer/tryout/samples/definitions/StarWars.graphql" target="_blank">StarWars.graphql</a> encoded in `Base64` format.
 

--- a/en/docs/create-api/create-and-deploy-apis/graphql/create-graphql-api-using-rest-api.md
+++ b/en/docs/create-api/create-and-deploy-apis/graphql/create-graphql-api-using-rest-api.md
@@ -40,8 +40,8 @@ Follow the instructions below to design a GraphQL API.
         ```
     === "Sample Request"
         ```
-        curl -k --location 'https://api.am.wso2.com:9095/api/configurator/1.3.0/apis/generate-configuration' \
-        --header 'Host: api.am.wso2.com' \
+        curl -k --location 'https://api.example.com:9095/api/configurator/1.3.0/apis/generate-configuration' \
+        --header 'Host: api.example.com' \
         --form 'definition=@"/Users/user/StarWarsAPI.graphql"' \
         --form 'apiType="GRAPHQL"' 
         ```
@@ -182,8 +182,8 @@ Follow the instructions below to design a GraphQL API.
         ```
     === "Sample Request"
         ```
-        curl -k --location 'https://api.am.wso2.com:9095/api/deployer/1.3.0/apis/deploy' \
-        --header 'Host: api.am.wso2.com' \
+        curl -k --location 'https://api.example.com:9095/api/deployer/1.3.0/apis/deploy' \
+        --header 'Host: api.example.com' \
         --header 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiZ2F0ZXdheV9jZXJ0aWZpY2F0ZV9hbGlhcyJ9.eyJpc3MiOiJodHRwczovL2lkcC5hbS53c28yLmNvbS90b2tlbiIsICJzdWIiOiI0NWYxYzVjOC1hOTJlLTExZWQtYWZhMS0wMjQyYWMxMjAwMDIiLCAiZXhwIjoxNjg4MTMxNDQ0LCAibmJmIjoxNjg4MTI3ODQ0LCAiaWF0IjoxNjg4MTI3ODQ0LCAianRpIjoiMDFlZTE3NDEtMDA0Ni0xOGE2LWFhMjEtYmQwYTk4ZjYzNzkwIiwgImNsaWVudElkIjoiNDVmMWM1YzgtYTkyZS0xMWVkLWFmYTEtMDI0MmFjMTIwMDAyIiwgInNjb3BlIjoiZGVmYXVsdCJ9.RfKQq2fUZKZFAyjimvsPD3cOzaVWazabmq7b1iKYacqIdNjkvO9CQmu7qdtrVNDmdZ_gHhWLXiGhN4UTSCXv_n1ArDnxTLFBroRS8dxuFBZoD9Mpj10vYFSDDhUfFqjgMqtpr30TpDMfee1wkqB6K757ZSjgCDa0hAbv555GkLdZtRsSgR3xWcxPBsIozqAMFDCWoUCbgTQuA5OiEhhpVco2zv4XLq2sz--VRoBieO12C69KnGRmoLuPtvOayInvrnV96Tbt9fR0fLS2l1nvAdFzVou0SIf9rMZLnURLVQQYE64GR14m-cFRYdUI9vTsFHZBl5w-uCLdzMMofzZaLQ' \
         --form 'apkConfiguration=@"/Users/user/StarWars.apk-conf"' \
         --form 'definitionFile=@"/Users/user/StarWarsAPI.graphql"'
@@ -265,15 +265,15 @@ You will need a GraphQL backend in order to invoke the API and get a correct res
 
 Once your GraphQL API has been deployed, you can invoke it. The endpoint of the API would be /`<apk-gateway-host>`/`<api-basepath>`. 
 
-For the above API, the base path is `/starwars/1.0.0`, and if the gateway host is `default.gw.wso2.com` so the API URL would be 
-`/default.gw.wso2.com/starwars/1.0.0`.
+For the above API, the base path is `/starwars/1.0.0`, and if the gateway host is `default.gw.example.com` so the API URL would be 
+`/default.gw.example.com/starwars/1.0.0`.
 
 A sample GraphQL call is provided below.
 
 === "Sample Request"
 ```
-curl --location 'https://default.gw.wso2.com:9095/starwars/1.0.0' \
---header 'Host: default.gw.wso2.com' \
+curl --location 'https://default.gw.example.com:9095/starwars/1.0.0' \
+--header 'Host: default.gw.example.com' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer <access-token>' \
 --data '{"query":"query hero ($episode: Episode) {\n    hero (episode: $episode) {\n        id\n        name\n        appearsIn\n    }\n}","variables":{"episode":"NEWHOPE"}}' -k

--- a/en/docs/create-api/create-and-deploy-apis/grpc/create-grpc-api-using-crs.md
+++ b/en/docs/create-api/create-and-deploy-apis/grpc/create-grpc-api-using-crs.md
@@ -1,28 +1,34 @@
-This guide shows you how to create a GRPC API using Kubernetes Custom Resources.
+This guide shows you how to create a gRPC API using Kubernetes Custom Resources.
 
-Similar to the approach for <a href="../../rest/create-rest-api-using-crs" target="_blank">REST APIs</a>, this approach requires three CRs.
+This approach requires four CRs.
 
 - API CR
 - GRPCRoute CR
+- ConfigMap CR
 - Backend CR
 
-For this guide, you can create a sample backend for the GRPC API using the following command.
+### Sample Backend for Student Service API
+
+We will use the sample Student Service backend for this guide, which can be created using the following command.
+
 ```
 kubectl apply -f https://raw.githubusercontent.com/wso2/apk/main/developer/tryout/samples/student-sample-backend.yaml -n <namespace>
 ```
 
-The GRPC definition file used for this guide is available at [this link](https://raw.githubusercontent.com/wso2/docs-apk/refs/heads/1.3.0/en/docs/assets/files/get-started/student.proto).
+You can check the status of the pods by using 
+```
+kubectl get pods -n <namespace>
+```
 
 !!! note
     - This guide uses the Student Service API, which has a single proto file for its definition. 
     - You can also use the [Order Service API](../../../assets/files/get-started/OrderDefinition.zip), which has **multiple proto files**. The backend for this API can be found at [https://raw.githubusercontent.com/wso2/apk/main/developer/tryout/samples/order-sample-backend.yaml](https://raw.githubusercontent.com/wso2/apk/main/developer/tryout/samples/order-sample-backend.yaml).
 
-#### API CR 
+### API CR 
 
-In the following CR, we have defined the GRPC API giving the name, context, and version information for the API. We have also referred to `GRPCRoute` resource in `spec.production.routeRefs[0]` path which we create in the next step.
+In the following CR, we have defined the gRPC API giving the name, context, and version information for the API. We have also referred to `GRPCRoute` resource in `spec.production.routeRefs[0]` path as well as `ConfigMap` resource in `spec.definitionFileRef` which we create in the next steps.
 
 ```yaml
----
 kind: "API"
 apiVersion: "dp.wso2.com/v1alpha3"
 metadata:
@@ -34,23 +40,24 @@ spec:
   basePath: "/org.apk.v1"
   organization: "default"
   isDefaultVersion: false
+  definitionFileRef: "student-service-definition"
   production:
   - routeRefs:
     - "student-service-api-route"
 ```
 
-#### GRPCRoute CR 
+### GRPCRoute CR 
 
-This is the resource where you define resources of your API. This `GRPCRoute` is linked to the API by referring to this resource name from the `API` resource. This GRPCRoute only points to some of the methods in the Student Service API.
+This is the CR where you define resources of your API. This `GRPCRoute` is linked to the API by referring to this resource name from the `API` resource. The given `GRPCRoute` only points to some of the methods in the Student Service API.
 
 ```yaml
-apiVersion: "gateway.networking.k8s.io/v1alpha2"
+apiVersion: "gateway.networking.k8s.io/v1"
 kind: "GRPCRoute"
 metadata:
   name: "student-service-api-route"
 spec:
   hostnames:
-  - "default.gw.wso2.com"
+  - "default.gw.example.com"
   rules:
   - matches:
     - method:
@@ -76,10 +83,22 @@ spec:
     name: "wso2-apk-default"
     sectionName: "httpslistener"
 ```
+### ConfigMap CR
 
-#### Backend CR 
+This resource contains the gRPC definition file for the API found in <a href="https://raw.githubusercontent.com/wso2/docs-apk/refs/heads/1.3.0/en/docs/assets/files/get-started/student.proto" target="_blank">Student.proto</a> encoded in Base64 format.
 
-In the above created GQLRoute resource we have referred to a `Backend` resource in `spec.rules[0].backendRefs[0]` path. That `Backend` should be created as below:
+```yaml
+kind: "ConfigMap"
+apiVersion: "v1"
+metadata:
+  name: "student-service-definition"
+binaryData:
+  definition: "H4sIAAAAAAAA/5WRu27DMAxFd30FkSlZDCQejQ6ZutcfYAg2Y6ixKVWkjBZB/j3yI21ebpBJFO69hwTJPyT6G95g4bwVmy4ypZwu97pGsL5OtNsn3TphCRWSFIy+MyVGk3ViLMGn7nTRhkaMa7DYmQY5wsSH6Lm0nJmx0Ty2bz6VkI9SPn0PCsC7Et5RJmU5vR/4FZBlBR4leGL4E9hZYlzB4ZjdxXPxqNt5CA86/MPKkapr2G3mhcF62Jaqu/meIefHVEelWmTut34dH5ZpSNINmCpeJM0eekfUYI5dDNVAuu0vuM5+8+NJNxFwAoO6PZ9JAgAA"
+```
+
+### Backend CR 
+
+In the above created `GRPCRoute` resource we have referred to a `Backend` resource in `spec.rules[0].backendRefs[0]` path. That `Backend` should be created as below:
 
 ```yaml
 apiVersion: "dp.wso2.com/v1alpha2"
@@ -101,7 +120,7 @@ This Backend CR points to the backend that can be created using the following co
 kubectl apply -f https://raw.githubusercontent.com/wso2/apk/main/developer/tryout/samples/student-sample-backend.yaml -n <namespace>
 ```
 
-The `host`, `port`, `basepath` fields should point to your GRPC backend.
+The `host`, `port`, `basepath` fields should point to your gRPC backend.
 If your backend is a Kubernetes-native `Service`, then derive the following value according to your `Service` and use it as the `host`. 
 
 ```
@@ -113,3 +132,32 @@ Once you have designed your APIs using these essential CRs, the next step is to 
 ```
 kubectl apply -f <path_to_CR_files> -n <namespace>
 ```
+
+### Invoking a gRPC API
+
+You will need a gRPC backend in order to invoke the API and get a correct response. A sample backend for the Student Service API has been provided under [this section.](#sample-backend-for-student-service-api)
+
+Once your gRPC API has been deployed, you can invoke it either via Postman, a custom client, or the `grpcurl` command-line tool. You can download the grpcurl tool from <a href="https://github.com/fullstorydev/grpcurl" target="_blank">here</a>. Code for custom clients can be <a href="https://grpc.io/docs/" target="_blank">generated</a> by providing the modified proto file to the Protocol buffer Compiler.
+
+If you are using grpcurl, you can view the various flags needed for sending requests <a href="https://github.com/fullstorydev/grpcurl" target="_blank">here</a>.
+
+<a href="../../../../develop-and-deploy-api/security/generate-access-token" target="_blank">Generate an access token</a> and invoke the sample gRPC call for the Student Service API provided below.
+
+=== "Sample Request"
+    ```
+    grpcurl -insecure \
+    -import-path /Users/User/proto-files \
+    -proto Student.proto \
+    -d '{"id": 1}' \
+    -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiZ2F0ZXdheV9jZXJ0aWZpY2F0ZV9hbGlhcyJ9.eyJpc3MiOiJodHRwczovL2lkcC5hbS53c28yLmNvbS90b2tlbiIsICJzdWI' \
+    default.gw.example.com:9095 org.apk.v1.student_service.StudentService/GetStudent
+    ```
+=== "Request Format"
+    ```
+    grpcurl -insecure \
+    -import-path <path-to-folder-containing-proto-file> \
+    -proto <proto-file-name> \
+    -d '{"argument": value}' \
+    -H 'Authorization: Bearer <Access-Token>' \
+    <Host>:9095 <complete-service-and-method-name>
+    ```

--- a/en/docs/create-api/create-and-deploy-apis/grpc/create-grpc-api-using-rest-api.md
+++ b/en/docs/create-api/create-and-deploy-apis/grpc/create-grpc-api-using-rest-api.md
@@ -25,9 +25,9 @@ If you wish to deploy an API with multiple .proto files, you can refer to <a hre
 
 ### Step 1 - Obtain the proto files for the given API
 
-Download and save the following file as Student.proto.
+Download and save the following file as <b>Student.proto</b>
 
-Student API: [Student.proto](https://raw.githubusercontent.com/wso2/docs-apk/refs/heads/1.3.0/en/docs/assets/files/get-started/student.proto)
+Student API: <a href="https://raw.githubusercontent.com/wso2/docs-apk/refs/heads/1.3.0/en/docs/assets/files/get-started/student.proto" target="_blank">Student.proto</a>
 
 ### Step 2 - Generate the APK configuration
 
@@ -40,8 +40,8 @@ Execute the following request to generate the APK configuration. Use the values 
 Student Service API:
 === "Sample Request"
     ```
-    curl -k --location 'https://api.am.wso2.com:9095/api/configurator/1.3.0/apis/generate-configuration' \
-    --header 'Host: api.am.wso2.com' \
+    curl -k --location 'https://api.example.com:9095/api/configurator/1.3.0/apis/generate-configuration' \
+    --header 'Host: api.example.com' \
     --form 'apiType="GRPC"' \
     --form 'definition=@"/Users/user/Student.proto"'
     ```
@@ -112,7 +112,6 @@ Your apk-conf file will now be as follows.
     basePath: "/org.apk"
     version: "v1"
     type: "GRPC"
-    id: "student-api"
     endpointConfigurations:
         production:
             - endpoint: "http://student-backend:6565"
@@ -145,11 +144,11 @@ After generating the token, you can deploy the gRPC API with the following comma
 
 === "Sample Request"
     ```
-    curl -k --location 'https://api.am.wso2.com:9095/api/deployer/1.3.0/apis/deploy' \
-    --header 'Host: api.am.wso2.com' \
+    curl -k --location 'https://api.example.com:9095/api/deployer/1.3.0/apis/deploy' \
+    --header 'Host: api.example.com' \
     --header 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiZ2F0ZXdheV9jZXJ0aWZpY2F0ZV9hbGlhcyJ9.eyJpc3MiOiJodHRwczovL2lkcC5hbS53c28yLmNvbS90b2tlbiIsICJzdWIiOiI0NWYxYzVjOC1hOTJlLTExZWQtYWZhMS0wMjQyYWMxMjAwMDIiLCAiZXhwIjoxNjg4MTMxNDQ0LCAibmJmIjoxNjg4MTI3ODQ0LCAiaWF0IjoxNjg4MTI3ODQ0LCAianRpIjoiMDFlZTE3NDEtMDA0Ni0xOGE2LWFhMjEtYmQwYTk4ZjYzNzkwIiwgImNsaWVudElkIjoiNDVmMWM1YzgtYTkyZS0xMWVkLWFmYTEtMDI0MmFjMTIwMDAyIiwgInNjb3BlIjoiZGVmYXVsdCJ9.RfKQq2fUZKZFAyjimvsPD3cOzaVWazabmq7b1iKYacqIdNjkvO9CQmu7qdtrVNDmdZ_gHhWLXiGhN4UTSCXv_n1ArDnxTLFBroRS8dxuFBZoD9Mpj10vYFSDDhUfFqjgMqtpr30TpDMfee1wkqB6K757ZSjgCDa0hAbv555GkLdZtRsSgR3xWcxPBsIozqAMFDCWoUCbgTQuA5OiEhhpVco2zv4XLq2sz--VRoBieO12C69KnGRmoLuPtvOayInvrnV96Tbt9fR0fLS2l1nvAdFzVou0SIf9rMZLnURLVQQYE64GR14m-cFRYdUI9vTsFHZBl5w-uCLdzMMofzZaLQ' \
-    --form 'apkConfiguration=@"path/to/apk-conf-file"' \
-    --form 'definitionFile=@"path/to/proto-definition"'
+    --form 'apkConfiguration=@"/Users/user/Student.apk-conf"' \
+    --form 'definitionFile=@"/Users/user/Student.proto"'
     ```
 === "Request Format"
     ```
@@ -199,23 +198,22 @@ kubectl get apis -n <namespace>
 
 ## Invoking a gRPC API
 
-You will need a gRPC backend in order to invoke the API and get a correct response. A sample backend for both the Student Service and Order Service APIs have been provided under [this section.](#sample-backend-for-student-service-api)
+You will need a gRPC backend in order to invoke the API and get a correct response. A sample backend for the Student Service API has been provided under [this section.](#sample-backend-for-student-service-api)
 
 Once your gRPC API has been deployed, you can invoke it either via Postman, a custom client, or the `grpcurl` command-line tool. You can download the grpcurl tool from <a href="https://github.com/fullstorydev/grpcurl" target="_blank">here</a>. Code for custom clients can be <a href="https://grpc.io/docs/" target="_blank">generated</a> by providing the modified proto file to the Protocol buffer Compiler.
 
 If you are using grpcurl, you can view the various flags needed for sending requests <a href="https://github.com/fullstorydev/grpcurl" target="_blank">here</a>.
 
-A sample gRPC call is provided below.
+<a href="../../../../develop-and-deploy-api/security/generate-access-token" target="_blank">Generate an access token</a> and invoke the sample gRPC call for the Student Service API provided below.
 
-Student Service API:
 === "Sample Request"
     ```
     grpcurl -insecure \
-    -import-path /Users/User/proto-files\
+    -import-path /Users/User/proto-files \
     -proto Student.proto \
     -d '{"id": 1}' \
     -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiZ2F0ZXdheV9jZXJ0aWZpY2F0ZV9hbGlhcyJ9.eyJpc3MiOiJodHRwczovL2lkcC5hbS53c28yLmNvbS90b2tlbiIsICJzdWI' \
-    default.gw.wso2.com:9095 org.apk.v1.student_service.StudentService/GetStudent
+    default.gw.example.com:9095 org.apk.v1.student_service.StudentService/GetStudent
     ```
 === "Request Format"
     ```
@@ -224,5 +222,5 @@ Student Service API:
     -proto <proto-file-name> \
     -d '{"argument": value}' \
     -H 'Authorization: Bearer <Access-Token>' \
-    default.gw.wso2.com:9095 <complete-service-and-method-name>
+    <Host>:9095 <complete-service-and-method-name>
     ```

--- a/en/docs/create-api/create-and-deploy-apis/grpc/create-grpc-api-with-multiple-proto-files.md
+++ b/en/docs/create-api/create-and-deploy-apis/grpc/create-grpc-api-with-multiple-proto-files.md
@@ -37,8 +37,8 @@ Execute the following request to generate the APK configuration. Use the values 
 
 === "Sample Request"
     ```
-    curl -k --location 'https://api.am.wso2.com:9095/api/configurator/1.3.0/apis/generate-configuration' \
-    --header 'Host: api.am.wso2.com' \
+    curl -k --location 'https://api.example.com:9095/api/configurator/1.3.0/apis/generate-configuration' \
+    --header 'Host: api.example.com' \
     --form 'apiType="GRPC"' \
     --form 'definition=@"/Users/user/OrderDefinition.zip"'
     ```
@@ -141,18 +141,18 @@ After generating the token, you can deploy the gRPC API with the following comma
 
 === "Sample Request"
     ```
-    curl -k --location 'https://api.am.wso2.com:9095/api/deployer/1.3.0/apis/deploy' \
-    --header 'Host: api.am.wso2.com' \
+    curl -k --location 'https://api.example.com:9095/api/deployer/1.3.0/apis/deploy' \
+    --header 'Host: api.example.com' \
     --header 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiZ2F0ZXdheV9jZXJ0aWZpY2F0ZV9hbGlhcyJ9.eyJpc3MiOiJodHRwczovL2lkcC5hbS53c28yLmNvbS90b2tlbiIsICJzdWIiOiI0NWYxYzVjOC1hOTJlLTExZWQtYWZhMS0wMjQyYWMxMjAwMDIiLCAiZXhwIjoxNjg4MTMxNDQ0LCAibmJmIjoxNjg4MTI3ODQ0LCAiaWF0IjoxNjg4MTI3ODQ0LCAianRpIjoiMDFlZTE3NDEtMDA0Ni0xOGE2LWFhMjEtYmQwYTk4ZjYzNzkwIiwgImNsaWVudElkIjoiNDVmMWM1YzgtYTkyZS0xMWVkLWFmYTEtMDI0MmFjMTIwMDAyIiwgInNjb3BlIjoiZGVmYXVsdCJ9.RfKQq2fUZKZFAyjimvsPD3cOzaVWazabmq7b1iKYacqIdNjkvO9CQmu7qdtrVNDmdZ_gHhWLXiGhN4UTSCXv_n1ArDnxTLFBroRS8dxuFBZoD9Mpj10vYFSDDhUfFqjgMqtpr30TpDMfee1wkqB6K757ZSjgCDa0hAbv555GkLdZtRsSgR3xWcxPBsIozqAMFDCWoUCbgTQuA5OiEhhpVco2zv4XLq2sz--VRoBieO12C69KnGRmoLuPtvOayInvrnV96Tbt9fR0fLS2l1nvAdFzVou0SIf9rMZLnURLVQQYE64GR14m-cFRYdUI9vTsFHZBl5w-uCLdzMMofzZaLQ' \
-    --form 'apkConfiguration=@"path/to/apk-conf-file.apk-conf"' \
-    --form 'definitionFile=@"<path/to/zip-file-containing-proto-definitions.zip>"'
+    --form 'apkConfiguration=@"/Users/user/Order.apk-conf"' \
+    --form 'definitionFile=@"/Users/user/OrderDefinition.zip"'
     ```
 === "Request Format"
     ```
     curl -k --location 'https://<host>:9095/api/deployer/1.3.0/apis/deploy' \
     --header 'Host: <host>' \
     --header 'Authorization: Bearer <access-token>' \
-    --form 'apkConfiguration=@"path/to/apk-conf-file.apk-conf"' \
+    --form 'apkConfiguration=@"<path/to/apk-conf-file.apk-conf>"' \
     --form 'definitionFile=@"<path/to/zip-file-containing-proto-definitions.zip>"'
     ```
 === "Sample Response"
@@ -198,7 +198,7 @@ Once your gRPC API has been deployed, you can invoke it either via Postman, a cu
 
 If you are using grpcurl, you can view the various flags needed for sending requests <a href="https://github.com/fullstorydev/grpcurl" target="_blank">here</a>.
 
-A sample gRPC call is provided below.
+<a href="../../../../develop-and-deploy-api/security/generate-access-token" target="_blank">Generate an access token</a> and invoke the sample gRPC call for the Student Service API provided below.
 
 === "Sample Request"
     ```
@@ -210,7 +210,7 @@ A sample gRPC call is provided below.
     -proto order.proto \
     -d '{"id": "1"}' \
     -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiZ2F0ZXdheV9jZXJ0aWZpY2F0ZV9hbGlhcyJ9.eyJpc3MiOiJodHRwczovL2lkcC5hbS53c28yLmNvbS90b2tlbiIsICJzdWI' \
-    default.gw.wso2.com:9095 grpcapi.v1.user.UserService/GetUser
+    default.gw.example.com:9095 grpcapi.v1.user.UserService/GetUser
     ```
 === "Request Format"
     ```
@@ -220,5 +220,5 @@ A sample gRPC call is provided below.
     -proto <file-2.proto> \
     -d '{"argument": value}' \
     -H 'Authorization: Bearer <Access-Token>' \
-    default.gw.wso2.com:9095 <complete-service-and-method-name>
+    <Host>:9095 <complete-service-and-method-name>
     ```

--- a/en/docs/create-api/create-and-deploy-apis/rest/create-rest-api-using-crs.md
+++ b/en/docs/create-api/create-and-deploy-apis/rest/create-rest-api-using-crs.md
@@ -1,5 +1,8 @@
-In this section, we'll explore Kubernetes Native API Development in WSO2 APK. Learn how to define APIs using Kubernetes resources for streamlined API management.
-A single API in APK project is defined using a set of combined Kubernetes custom resources (CRs).
+In this section, we'll explore how to define APIs using Kubernetes resources in WSO2 Kubernetes Gateway for streamlined API management.
+
+## Create the CRs
+
+A single API is defined using a set of combined Kubernetes custom resources (CRs) in WSO2 Kubernetes Gateway.
 
 - <b>API</b> - With the `API` CRs, you can effortlessly design and manage APIs using Kubernetes-native tools. Simplify the deployment process and focus on what matters most – crafting outstanding APIs. This is the root level resource for an API. API related metadata are also defined in this CR.
 
@@ -7,7 +10,7 @@ A single API in APK project is defined using a set of combined Kubernetes custom
 
 - <b>Backend</b> - Elevate your endpoint configurations, including resiliency settings, using the `Backend` CR. Ensure the reliability and availability of your API backends for uninterrupted service.
 
-These are the basic resource you need to use specifically for APK. We have other resources for complex use cases which are described under separate sections.
+These are the basic resource you need to use specifically for Kubernetes Gateway. We have other resources for complex use cases which are described under separate sections.
 
 Let's create a simple API with following steps:
 
@@ -15,75 +18,85 @@ Let's create a simple API with following steps:
 - [Create HTTPRoute CR](#create-httproute-cr)
 - [Create Backend CR](#create-backend-cr)
 
-## Create API CR 
+### Create API CR 
 
-In the following CR, we have defined a REST API giving the name, context, and version information for the API. We have also referred to `HTTPRoute` resource in `spec.production.httpRouteRefs[0]` path which we create in the next step.
+In the following CR, we have defined a REST API giving the name, context, and version information for the API. We have also referred to the `HTTPRoute` resource (which we create in the next step) in the `spec.production.httpRouteRefs[0]` path.
 
-```
+```yaml
 apiVersion: dp.wso2.com/v1alpha1
 kind: API
 metadata:
-  name: http-bin-api
+  name: sample-api
 spec:
-  apiName: HTTP Bin API
+  apiName: Sample API
   apiType: REST
-  apiVersion: 1.0.0
-  basePath: /http-bin-api/1.0.0
+  apiVersion: 0.1.0
+  basePath: /sample-api/0.1.0
   organization: default
   production:
   - httpRouteRefs:
-    - prod-http-route-http-bin-api
+    - prod-http-route-sample-api
 ```
 
 !!! Info
     If your API has many resources and cannot be defined within a single `HTTPRoute` resource, then you have to create two or more `HTTPRoute`s and list them under `spec.production.httpRouteRefs`.
 
-## Create HTTPRoute CR
+### Create HTTPRoute CR
 
 This is the resource where you define resources of your API. This `HTTPRoute` is linked to the API by referring to this resource name from the `API` resource.
 
-```
+```yaml
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
-  name: prod-http-route-http-bin-api
+  name: prod-http-route-sample-api
 spec:
   hostnames:
-    - http-bin.gw.wso2.com
+  - default.gw.example.com
   parentRefs:
-    - group: gateway.networking.k8s.io
-      kind: Gateway
-      name: wso2-apk-default
-      sectionName: httpslistener
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: wso2-apk-default
+    sectionName: httpslistener
   rules:
-  - backendRefs:
-    - group: dp.wso2.com
-      kind: Backend
-      name: http-bin-backend
-    matches:
+  - matches:
     - path:
-        type: PathPrefix
-        value: /
+        type: "RegularExpression"
+        value: "/uuid"
+      method: "GET"
+    filters:
+    - type: "URLRewrite"
+      urlRewrite:
+        path:
+          type: "ReplaceFullPath"
+          replaceFullPath: "/uuid"
+    backendRefs:
+    - group: "dp.wso2.com"
+      kind: "Backend"
+      name: "backend-sample-api"
 ```
 
-Here, we have used `http-bin.gw.wso2.com` as the virtual hostname for this API. The `spec.parentRefs[0]` parameter defines the Gateway to which this `HTTPRoute` is deployed. We have defined a single rule with a `PathPrefix` match type, and the `URLRewrite` filter with `ReplacePrefixMatch` to rewrite the API context prefix so that only the remainder of the path is sent to the actual backend.
+Here, we have used `default.gw.example.com` as the virtual hostname for this API. The `spec.parentRefs[0]` parameter defines the Gateway to which this `HTTPRoute` is deployed. We have defined a single rule with a `RegularExpression` match type for the path, and the `URLRewrite` filter with `ReplaceFullPath` to rewrite the entire path so that the specified path is sent to the actual backend.
 
-## Create Backend CR
+### Create Backend CR
 
 In the above created HTTPRoute resource we have referred to a `Backend` resource in `spec.rules[0].backendRefs[0]` path. That `Backend` should be created as below:
 
-```
-apiVersion: dp.wso2.com/v1alpha1
+```yaml
+apiVersion: dp.wso2.com/v1alpha2
 kind: Backend
 metadata:
-  name: http-bin-backend
+  name: backend-sample-api
 spec:
   services:
-  - host: httpbin.org
-    port: 80
+  - host: dev-tools.wso2.com
+    port: 443
+  basePath: /gs/helpers/v1.0
+  protocol: https
 ```
 
-Here, we have set the httpbin.org domain name as the host with port 80, which is an insecure port. To make it a TLS-secured endpoint, refer to the [Manage Certificate]({{base_path}}/en/latest/create-api/manage-service-endpoint/manage-certificate/) section.
+!!! Info
+    In order to make the endpoint a TLS-secured endpoint, refer to the <a href="../../../manage-service-endpoint/manage-certificate/" target="_blank">Manage Certificate</a> section.
 
 If your backend is a Kubernetes-native `Service`, then derive the following value according to your `Service` and use it as the `host`. 
 
@@ -91,8 +104,32 @@ If your backend is a Kubernetes-native `Service`, then derive the following valu
 <spec.metadata.name>.<spec.metadata.namespace>
 ```
 
+## Apply the CRs and Invoke the API
+
 Once you have designed your APIs using these essential CRs, the next step is to apply them to the Kubernetes API server. APK will process and deploy your APIs seamlessly, taking full advantage of the Kubernetes infrastructure.
 
 ```
 kubectl apply -f <path_to_CR_files>
 ```
+
+Now the API is ready to be invoked. Let’s <a href="../../../../develop-and-deploy-api/security/generate-access-token" target="_blank">Generate an Access Token</a> and get a random UUID by invoking the `/uuid` resource in the `SampleServiceAPI` by invoking the API.
+
+=== "Sample Request"
+    ```
+    curl -k --location 'https://default.gw.example.com:9095/sample-api/0.1.0/uuid' \
+    --header 'Host: default.gw.example.com' \
+    --header 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiZ2F0ZXdheV9jZXJ0aWZpY2F0ZV9hbGlhcyJ9.eyJpc3MiOiJodHRwczovL2lkcC5hbS53c28yLmNvbS90b2tlbiIsICJzdWIiOiI0NWYxYzVjOC1hOTJlLTExZWQtYWZhMS0wMjQyYWMxMjAwMDIiLCAiZXhwIjoxNjg4MTMxNDQ0LCAibmJmIjoxNjg4MTI3ODQ0LCAiaWF0IjoxNjg4MTI3ODQ0LCAianRpIjoiMDFlZTE3NDEtMDA0Ni0xOGE2LWFhMjEtYmQwYTk4ZjYzNzkwIiwgImNsaWVudElkIjoiNDVmMWM1YzgtYTkyZS0xMWVkLWFmYTEtMDI0MmFjMTIwMDAyIiwgInNjb3BlIjoiZGVmYXVsdCJ9.RfKQq2fUZKZFAyjimvsPD3cOzaVWazabmq7b1iKYacqIdNjkvO9CQmu7qdtrVNDmdZ_gHhWLXiGhN4UTSCXv_n1ArDnxTLFBroRS8dxuFBZoD9Mpj10vYFSDDhUfFqjgMqtpr30TpDMfee1wkqB6K757ZSjgCDa0hAbv555GkLdZtRsSgR3xWcxPBsIozqAMFDCWoUCbgTQuA5OiEhhpVco2zv4XLq2sz--VRoBieO12C69KnGRmoLuPtvOayInvrnV96Tbt9fR0fLS2l1nvAdFzVou0SIf9rMZLnURLVQQYE64GR14m-cFRYdUI9vTsFHZBl5w-uCLdzMMofzZaLQ'
+    ```
+
+=== "Sample Response"
+    ```
+    {
+        "uuid":"f4a38d31-21e8-4b5d-9c26-792e6805dd54"
+    }
+    ```
+=== "Request Format"
+    ```
+    curl --location 'https://<host>:9095/<basePath>/0.1.0/uuid' \
+    --header 'Host: <host>' \
+    --header 'Authorization: Bearer <access-token>'
+    ```

--- a/en/docs/create-api/weighted-routing/weighted-routing-via-crs.md
+++ b/en/docs/create-api/weighted-routing/weighted-routing-via-crs.md
@@ -202,7 +202,7 @@ Apply the CRs to the Kubernetes API server using the following command.
 
 ### Step 4 - Verify the API Invocation
 
-<a href="../../../get-started/quick-start-guide/#step-4-generate-access-token" target="_blank">Generate an access token</a> and invoke the API using the following command:
+<a href="../../../develop-and-deploy-api/security/generate-access-token" target="_blank">Generate an access token</a> and invoke the API using the following command:
 
 === "Sample Request"
     ```

--- a/en/docs/create-api/weighted-routing/weighted-routing-via-rest-api.md
+++ b/en/docs/create-api/weighted-routing/weighted-routing-via-rest-api.md
@@ -123,7 +123,7 @@ Deploy the sample backend resources using the following command.
 
 #### 2. Deploy the API with APK-Conf
 
-<a href="../../../get-started/quick-start-guide/#step-4-generate-access-token" target="_blank">Generate an access token</a> and deploy the API with APK-Conf file by following the steps in <a href="../../../get-started/quick-start-guide/#step-5-deploy-and-invoke-the-api" target="_blank">Deploy the API in Kubernetes Gateway</a>
+<a href="../../../develop-and-deploy-api/security/generate-access-token" target="_blank">Generate an access token</a> and deploy the API with APK-Conf file by following the steps in <a href="../../../get-started/quick-start-guide/#step-5-deploy-and-invoke-the-api" target="_blank">Deploy the API in Kubernetes Gateway</a>
 
 ### Step 4 - Verify the API Invocation
 

--- a/en/docs/develop-and-deploy-api/security/generate-access-token.md
+++ b/en/docs/develop-and-deploy-api/security/generate-access-token.md
@@ -23,8 +23,8 @@ Execute the following request to generate the access token. Use the base64 encod
 === "Sample Request"
 
     ```
-       curl -k --location 'https://idp.am.wso2.com:9095/oauth2/token' \
-       --header 'Host: idp.am.wso2.com' \
+       curl -k --location 'https://idp.example.com:9095/oauth2/token' \
+       --header 'Host: idp.example.com' \
        --header 'Authorization: Basic NDVmMWM1YzgtYTkyZS0xMWVkLWFmYTEtMDI0MmFjMTIwMDAyOjRmYmQ2MmVjLWE5MmUtMTFlZC1hZmExLTAyNDJhYzEyMDAwMg==' \
        --header 'Content-Type: application/x-www-form-urlencoded' \
        --data-urlencode 'grant_type=client_credentials' \

--- a/en/docs/develop-and-deploy-api/security/generate-access-token.md
+++ b/en/docs/develop-and-deploy-api/security/generate-access-token.md
@@ -12,29 +12,29 @@ Execute the following request to generate the access token. Use the base64 encod
 === "Request"
 
     ```
-       curl --location 'https://<host>:9095/oauth2/token' \
-       --header 'Host: <host>' \
-       --header 'Authorization: Basic <Base64Encoded(clientId:clientSecret)>' \
-       --header 'Content-Type: application/x-www-form-urlencoded' \
-       --data-urlencode 'grant_type=client_credentials' \
-       --data-urlencode 'scope=apk:api_create'
+    curl --location 'https://<host>:9095/oauth2/token' \
+    --header 'Host: <host>' \
+    --header 'Authorization: Basic <Base64Encoded(clientId:clientSecret)>' \
+    --header 'Content-Type: application/x-www-form-urlencoded' \
+    --data-urlencode 'grant_type=client_credentials' \
+    --data-urlencode 'scope=apk:api_create'
     ```
 
 === "Sample Request"
 
     ```
-       curl -k --location 'https://idp.example.com:9095/oauth2/token' \
-       --header 'Host: idp.example.com' \
-       --header 'Authorization: Basic NDVmMWM1YzgtYTkyZS0xMWVkLWFmYTEtMDI0MmFjMTIwMDAyOjRmYmQ2MmVjLWE5MmUtMTFlZC1hZmExLTAyNDJhYzEyMDAwMg==' \
-       --header 'Content-Type: application/x-www-form-urlencoded' \
-       --data-urlencode 'grant_type=client_credentials' \
-       --data-urlencode 'scope=apk:api_create'
+    curl -k --location 'https://idp.example.com:9095/oauth2/token' \
+    --header 'Host: idp.example.com' \
+    --header 'Authorization: Basic NDVmMWM1YzgtYTkyZS0xMWVkLWFmYTEtMDI0MmFjMTIwMDAyOjRmYmQ2MmVjLWE5MmUtMTFlZC1hZmExLTAyNDJhYzEyMDAwMg==' \
+    --header 'Content-Type: application/x-www-form-urlencoded' \
+    --data-urlencode 'grant_type=client_credentials' \
+    --data-urlencode 'scope=apk:api_create'
     ```
 
 === "Sample Response"
 
     ```
-       {"access_token":"eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiZ2F0ZXdheV9jZXJ0aWZpY2F0ZV9hbGlhcyJ9.eyJpc3MiOiJodHRwczovL2lkcC5hbS53c28yLmNvbS90b2tlbiIsICJzdWIiOiI0NWYxYzVjOC1hOTJlLTExZWQtYWZhMS0wMjQyYWMxMjAwMDIiLCAiZXhwIjoxNjg4MTMxNDQ0LCAibmJmIjoxNjg4MTI3ODQ0LCAiaWF0IjoxNjg4MTI3ODQ0LCAianRpIjoiMDFlZTE3NDEtMDA0Ni0xOGE2LWFhMjEtYmQwYTk4ZjYzNzkwIiwgImNsaWVudElkIjoiNDVmMWM1YzgtYTkyZS0xMWVkLWFmYTEtMDI0MmFjMTIwMDAyIiwgInNjb3BlIjoiZGVmYXVsdCJ9.RfKQq2fUZKZFAyjimvsPD3cOzaVWazabmq7b1iKYacqIdNjkvO9CQmu7qdtrVNDmdZ_gHhWLXiGhN4UTSCXv_n1ArDnxTLFBroRS8dxuFBZoD9Mpj10vYFSDDhUfFqjgMqtpr30TpDMfee1wkqB6K757ZSjgCDa0hAbv555GkLdZtRsSgR3xWcxPBsIozqAMFDCWoUCbgTQuA5OiEhhpVco2zv4XLq2sz--VRoBieO12C69KnGRmoLuPtvOayInvrnV96Tbt9fR0fLS2l1nvAdFzVou0SIf9rMZLnURLVQQYE64GR14m-cFRYdUI9vTsFHZBl5w-uCLdzMMofzZaLQ", "token_type":"Bearer", "expires_in":3600, "scope": "apk:api_create"}
+    {"access_token":"eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiZ2F0ZXdheV9jZXJ0aWZpY2F0ZV9hbGlhcyJ9.eyJpc3MiOiJodHRwczovL2lkcC5hbS53c28yLmNvbS90b2tlbiIsICJzdWIiOiI0NWYxYzVjOC1hOTJlLTExZWQtYWZhMS0wMjQyYWMxMjAwMDIiLCAiZXhwIjoxNjg4MTMxNDQ0LCAibmJmIjoxNjg4MTI3ODQ0LCAiaWF0IjoxNjg4MTI3ODQ0LCAianRpIjoiMDFlZTE3NDEtMDA0Ni0xOGE2LWFhMjEtYmQwYTk4ZjYzNzkwIiwgImNsaWVudElkIjoiNDVmMWM1YzgtYTkyZS0xMWVkLWFmYTEtMDI0MmFjMTIwMDAyIiwgInNjb3BlIjoiZGVmYXVsdCJ9.RfKQq2fUZKZFAyjimvsPD3cOzaVWazabmq7b1iKYacqIdNjkvO9CQmu7qdtrVNDmdZ_gHhWLXiGhN4UTSCXv_n1ArDnxTLFBroRS8dxuFBZoD9Mpj10vYFSDDhUfFqjgMqtpr30TpDMfee1wkqB6K757ZSjgCDa0hAbv555GkLdZtRsSgR3xWcxPBsIozqAMFDCWoUCbgTQuA5OiEhhpVco2zv4XLq2sz--VRoBieO12C69KnGRmoLuPtvOayInvrnV96Tbt9fR0fLS2l1nvAdFzVou0SIf9rMZLnURLVQQYE64GR14m-cFRYdUI9vTsFHZBl5w-uCLdzMMofzZaLQ", "token_type":"Bearer", "expires_in":3600, "scope": "apk:api_create"}
     ```
 
 Now you can use this access token to invoke the Resources and APIs that follow.

--- a/en/docs/get-started/quick-start-guide-with-cp.md
+++ b/en/docs/get-started/quick-start-guide-with-cp.md
@@ -164,9 +164,8 @@ You now have the API Definition (`SampleAPIDefinition.json`) and the apk-conf fi
     | apkConfiguration | `SampleService.apk-conf` file   | :material-check: |
     | definitionFile   | `SampleAPIDefinition.json` file | :material-check: |
 
-2. Set the access token in the Authorization header as a bearer token. This is the access token received by following the steps under the <a href="../quick-start-guide#generate-an-access-token-to-invoke-apis" target="_blank">Generate an access token to invoke APIs section</a> above.
 
-3. You can generate the Kubernetes custom resources as a zip file from the config-deployer service using the following command.
+2. You can generate the Kubernetes custom resources as a zip file from the config-deployer service using the following command.
 
     === "Sample Request"
         ```
@@ -188,13 +187,13 @@ You now have the API Definition (`SampleAPIDefinition.json`) and the apk-conf fi
         -k --output <path/and/name-for-generated-zip-file.zip>
         ```
 
-4. Once you have generated your K8s artifacts, the next step is to apply them to  the Kubernetes API server.
+3. Once you have generated your K8s artifacts, the next step is to apply them to  the Kubernetes API server.
 
     ```
     kubectl apply -n apk -f <path_to_extracted_zip_file>
     ```
 
-5. Execute the command below. You will be able to see that the `SampleServiceAPI` is successfully deployed as shown in the image.
+4. Execute the command below. You will be able to see that the `SampleServiceAPI` is successfully deployed as shown in the image.
 
 
     === "Command"
@@ -206,17 +205,17 @@ You now have the API Definition (`SampleAPIDefinition.json`) and the apk-conf fi
 
 ## Step 3 - Manage API From Control Plane
 
-1. Login to the Publisher Console ([https://am.wso2.com/publisher](https://am.wso2.com/publisher)) of the WSO2 API Manager.
+1. Login to the Publisher Console (<a href="https://am.wso2.com/publisher" target="_blank">https://am.wso2.com/publisher</a>) of the WSO2 API Manager.
 
-    you can see the deploy SampleService API as below.
+    you can see the deployed SampleService API as below.
 
     [![ControlPlane API](../assets/img/control-plane/cp-overview.png)](../assets/img/control-plane/cp-overview.png)
 
-2. Once you click the API you will redirect to overciew page.
+2. Once you click the API you will be redirected to the overview page.
 
     [![ControlPlaneOverview API](../assets/img/control-plane/main-overview.png)](../assets/img/control-plane/main-overview.png)
 
-3. Now you can edit portal cnfigurations such as basic info, documentation etc.
+3. Now you can edit portal configurations such as basic info, documentation etc.
 
     [![ControlPlaneBasic API](../assets/img/control-plane/portal-conf.png)](../assets/img/control-plane/portal-conf.png)
 
@@ -225,7 +224,7 @@ You now have the API Definition (`SampleAPIDefinition.json`) and the apk-conf fi
 
 ## Step 4 - Create Application and Subscribe to the API
 
-1. Login to the Developer Portal ([https://am.wso2.com/devportal](https://am.wso2.com/devportal)) of the WSO2 API Manager.
+1. Login to the Developer Portal (<a href="https://am.wso2.com/devportal" target="_blank">https://am.wso2.com/devportal</a>) of the WSO2 API Manager.
 2. Click on the `Applications` tab and then use `ADD NEW APPLICATION` option.
 3. Provide the information as given below and click `Save`.
 
@@ -251,7 +250,9 @@ You now have the API Definition (`SampleAPIDefinition.json`) and the apk-conf fi
 
 ## Step 5 - Invoke the API
 
-1. Use the following command to invoke the API using the access token generated in the previous step.
+1. Generate an access token by following the steps under <a href="../quick-start-guide#generate-an-access-token-to-invoke-apis" target="_blank">Generate an access token to invoke APIs</a> section.
+
+2. Use the following command to invoke the API using the access token generated in the previous step.
 
     ```bash
     curl -X GET "https://carbon.super.gw.wso2.com:9095/sample-api/0.1.0/uuid" -H "Authorization: Bearer <access-token>" -k

--- a/en/docs/includes/apk-conf-cr-deploy.md
+++ b/en/docs/includes/apk-conf-cr-deploy.md
@@ -1,7 +1,7 @@
 You can generate K8s resources as a zip file from config-deployer service.
 
 ```
-curl --location 'https://api.am.wso2.com:9095/api/configurator/1.3.0/apis/generate-k8s-resources' \
+curl --location 'https://api.example.com:9095/api/configurator/1.3.0/apis/generate-k8s-resources' \
 --header 'Content-Type: multipart/form-data' \
 --header 'Accept: application/zip' \
 --form 'apkConfiguration=@"/Users/user/SampleService.apk-conf"' \

--- a/en/docs/includes/create-apk-conf-api.md
+++ b/en/docs/includes/create-apk-conf-api.md
@@ -2,25 +2,13 @@
    
 To begin, it's essential to have a backend service that your API will interact with. The Kubernetes Gateway Configuration file is generated based on the API schema, which, in turn, relies on the functionality of your backend service. 
 
-In this guide, we will be using a backend deployed in a Kubernetes cluster. Prior to invoking the API, you will need to have this backend up and running.
-
-You can create this sample backend with the following command.
-
-``` bash
-kubectl apply -f https://raw.githubusercontent.com/wso2/apk/main/developer/tryout/samples/qsg-sample-backend.yaml
-```
-
-Wait for this pod to spin up. You can check its status using the following command.
-
-``` bash
-kubectl get pods
-```
+This guide utilizes a pre-existing backend service hosted in the cloud. When using your own backend deployed in a Kubernetes cluster, ensure that backend is up and running prior to invoking the API.
 
 ## Step 2. Generate an API schema file for your service. 
 
 You will need an OpenAPI Specification 3.x that describes the structure and behavior of your API. This file serves as the foundation for configuring your API and is essential for generating the Kubernetes Gateway Configuration file.
 
-Download and save the sample [SampleAPIDefinition.json](https://raw.githubusercontent.com/wso2/docs-apk/refs/heads/1.3.0/en/docs/assets/files/get-started/SampleAPIDefinition.json) file. This is the OAS definition of the API that we are going to deploy in Kubernetes Gateway.
+Download and save the sample <a href="https://raw.githubusercontent.com/wso2/docs-apk/refs/heads/1.3.0/en/docs/assets/files/get-started/SampleAPIDefinition.json" target="_blank">SampleAPIDefinition.json</a> file. This is the OAS definition of the API that we are going to deploy in Kubernetes Gateway.
 
 ## Step 3. Generate Kubernetes Gateway configuration file.
     
@@ -31,8 +19,8 @@ The OpenAPI specification file can be provided as a local file or as a URL conta
 1. As a local file
 
     ```bash
-    curl -k --location 'https://api.am.wso2.com:9095/api/configurator/1.3.0/apis/generate-configuration' \
-    --header 'Host: api.am.wso2.com' \
+    curl -k --location 'https://api.example.com:9095/api/configurator/1.3.0/apis/generate-configuration' \
+    --header 'Host: api.example.com' \
     --form 'definition=@"/Users/user/SampleAPIDefinition.json"'
     ```
 
@@ -43,9 +31,9 @@ The OpenAPI specification file can be provided as a local file or as a URL conta
     OpenAPI Specification for REST API:
 
     ```bash
-    curl -k --location 'https://api.am.wso2.com:9095/api/configurator/1.3.0/apis/generate-configuration' \
-    --header 'Host: api.am.wso2.com' \
-    ---form 'url="https://raw.githubusercontent.com/wso2/docs-apk/refs/heads/1.3.0/en/docs/assets/files/get-started/SampleAPIDefinition.json"' \
+    curl -k --location 'https://api.example.com:9095/api/configurator/1.3.0/apis/generate-configuration' \
+    --header 'Host: api.example.com' \
+    --form 'url="https://raw.githubusercontent.com/wso2/docs-apk/refs/heads/1.3.0/en/docs/assets/files/get-started/SampleAPIDefinition.json"' \
     --form 'apiType="REST"'
     ```
 

--- a/en/docs/includes/direct-deploy.md
+++ b/en/docs/includes/direct-deploy.md
@@ -1,7 +1,7 @@
 You can deploy the API directly into Kubernetes Gateway using API Schema definition and Kubernetes Gateway configuration file using the command below.
 
 ```
-curl --location 'https://api.am.wso2.com:9095/api/deployer/1.3.0/apis/deploy' \
+curl --location 'https://api.example.com:9095/api/deployer/1.3.0/apis/deploy' \
 --header 'Content-Type: multipart/form-data' \
 --header 'Accept: application/yaml' \
 --header 'Authorization: Bearer <Access Token From IDP>' \

--- a/en/docs/includes/post-create-apk-conf-api.md
+++ b/en/docs/includes/post-create-apk-conf-api.md
@@ -10,3 +10,28 @@ Once you have crafted your APK Configuration File, you have two convenient optio
 ### Option 2 - Generate K8s CRs using config generator tool and Deploy the API using Kubernetes Client
 
 {!includes/apk-conf-cr-deploy.md!}
+
+
+## Step 7. Invoke the API.
+
+Now the API is ready to be invoked. Let’s get a random UUID by invoking the `/uuid` resource in the `SampleServiceAPI` by invoking the API.
+
+=== "Sample Request"
+    ```
+    curl -k --location 'https://default.gw.example.com:9095/sample-api/0.1.0/uuid' \
+    --header 'Host: default.gw.example.com' \
+    --header 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiZ2F0ZXdheV9jZXJ0aWZpY2F0ZV9hbGlhcyJ9.eyJpc3MiOiJodHRwczovL2lkcC5hbS53c28yLmNvbS90b2tlbiIsICJzdWIiOiI0NWYxYzVjOC1hOTJlLTExZWQtYWZhMS0wMjQyYWMxMjAwMDIiLCAiZXhwIjoxNjg4MTMxNDQ0LCAibmJmIjoxNjg4MTI3ODQ0LCAiaWF0IjoxNjg4MTI3ODQ0LCAianRpIjoiMDFlZTE3NDEtMDA0Ni0xOGE2LWFhMjEtYmQwYTk4ZjYzNzkwIiwgImNsaWVudElkIjoiNDVmMWM1YzgtYTkyZS0xMWVkLWFmYTEtMDI0MmFjMTIwMDAyIiwgInNjb3BlIjoiZGVmYXVsdCJ9.RfKQq2fUZKZFAyjimvsPD3cOzaVWazabmq7b1iKYacqIdNjkvO9CQmu7qdtrVNDmdZ_gHhWLXiGhN4UTSCXv_n1ArDnxTLFBroRS8dxuFBZoD9Mpj10vYFSDDhUfFqjgMqtpr30TpDMfee1wkqB6K757ZSjgCDa0hAbv555GkLdZtRsSgR3xWcxPBsIozqAMFDCWoUCbgTQuA5OiEhhpVco2zv4XLq2sz--VRoBieO12C69KnGRmoLuPtvOayInvrnV96Tbt9fR0fLS2l1nvAdFzVou0SIf9rMZLnURLVQQYE64GR14m-cFRYdUI9vTsFHZBl5w-uCLdzMMofzZaLQ'
+    ```
+
+=== "Sample Response"
+    ```
+    {
+        "uuid":"f4a38d31-21e8-4b5d-9c26-792e6805dd54"
+    }
+    ```
+=== "Request Format"
+    ```
+    curl --location 'https://<host>:9095/<basePath>/0.1.0/uuid' \
+    --header 'Host: <host>' \
+    --header 'Authorization: Bearer <access-token>'
+    ```


### PR DESCRIPTION
## Purpose
> Updating the `hostname` to match the QSG in DP to CP Quick Start Guide and other improvements.
> Updating the `hostname` to match the QSG in the guide to generate an Access Token.
> Updating `hostname` to match the QSG in guides to Develop and Deploy APIs for `REST API`,  `GraphQL API`, `AI API` as well as `gRPC API`. And other bug fixes and improvements.
> Updating the Generate Access Token in Weighted Routing documentation to match other guides.