### PR TITLE
Add arm compatibility to installation prerequisites

### DIFF
--- a/en/docs/setup/prerequisites.md
+++ b/en/docs/setup/prerequisites.md
@@ -97,3 +97,9 @@ In addition to Kubernetes and Helm, WSO2 Kubernetes Gateway requires several oth
 **Note**: Docker version within the Kubernetes cluster may vary. To ensure compatibility with Kubernetes Gateway, confirm that your Docker version meets the minimum requirement listed above.
 
 **Note**: PostgreSQL is used in the Quick Start Guide for token generation from the non-production IdP.
+
+### ARM compatibility
+
+WSO2 Kubernetes Gateway is compatible with ARM processors. It can run on ARM-based systems, such as those with Apple Silicon or ARM-based Linux distributions.
+
+Note: Use a Redis Docker image that includes an ARM-compatible release.


### PR DESCRIPTION
## Purpose
> Test compatibility of WSO2 Kubernetes Gateway on Linux ARM.
Related issue - https://github.com/wso2-enterprise/wso2-apim-internal/issues/9895

### Approach
> Tested on a AKS cluster using nodes with Ubuntu 22.04 and arm64 CPU architecture.