### PR TITLE
Docs for adding custom pod annotations, labels, and node selectors and adding sidecar containers to the gateway pod

### DIFF
--- a/en/docs/catalogs/config-catalog.md
+++ b/en/docs/catalogs/config-catalog.md
@@ -79,6 +79,8 @@ A Helm chart for Kubernetes Gateway components
 | wso2.apk.dp.configdeployer.enabled | bool | `true` |  |
 | wso2.apk.dp.configdeployer.deployment.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/app","operator":"In","values":["config-ds"]}]}}}]}}` | Configure Affinity for the deployment.  |
 | wso2.apk.dp.configdeployer.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
+| wso2.apk.dp.configdeployer.deployment.pod.annotations | object | `{}` | Annotations for pods. |
+| wso2.apk.dp.configdeployer.deployment.pod.labels | object | `{}` | Labels for pods. |
 | wso2.apk.dp.configdeployer.deployment.resources.requests.memory | string | `"128Mi"` | CPU request for the container |
 | wso2.apk.dp.configdeployer.deployment.resources.requests.cpu | string | `"100m"` | Memory request for the container |
 | wso2.apk.dp.configdeployer.deployment.resources.limits.memory | string | `"1028Mi"` | CPU limit for the container |
@@ -116,6 +118,8 @@ A Helm chart for Kubernetes Gateway components
 | wso2.apk.dp.adapter.deployment.security.sslHostname | string | `"adapter"` | Enable security for adapter. |
 | wso2.apk.dp.adapter.deployment.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/app","operator":"In","values":["adapter"]}]}}}]}}` | Configure Affinity for the deployment.  |
 | wso2.apk.dp.adapter.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
+| wso2.apk.dp.adapter.deployment.pod.annotations | object | `{}` | Annotations for pods. |
+| wso2.apk.dp.adapter.deployment.pod.labels | object | `{}` | Labels for pods. |
 | wso2.apk.dp.adapter.configs.apiNamespaces | string | `nil` | Optionally configure namespaces to watch for apis. |
 | wso2.apk.dp.adapter.configs.tls.secretName | string | `""` | TLS secret name for adapter public certificate. |
 | wso2.apk.dp.adapter.configs.tls.certKeyFilename | string | `""` | TLS certificate file name. |
@@ -141,6 +145,8 @@ A Helm chart for Kubernetes Gateway components
 | wso2.apk.dp.commonController.deployment.configs.apiNamespaces | list | `["apk-v12"]` | Optionally configure namespaces to watch for apis,ratelimitpolicies,etc. |
 | wso2.apk.dp.commonController.deployment.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/app","operator":"In","values":["common-controller"]}]}}}]}}` | Configure Affinity for the deployment.  |
 | wso2.apk.dp.commonController.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
+| wso2.apk.dp.commonController.deployment.pod.annotations | object | `{}` | Annotations for pods. |
+| wso2.apk.dp.commonController.deployment.pod.labels | object | `{}` | Labels for pods. |
 | wso2.apk.dp.commonController.deployment.redis.host | string | `"redis-master"` | Redis host |
 | wso2.apk.dp.commonController.deployment.redis.port | string | `"6379"` | Redis port |
 | wso2.apk.dp.commonController.deployment.redis.username | string | `"default"` | Redis user name |
@@ -186,9 +192,15 @@ A Helm chart for Kubernetes Gateway components
 | wso2.apk.dp.ratelimiter.deployment.configs.tls.certCAFilename | string | `""` | TLS CA certificate file name. |
 | wso2.apk.dp.ratelimiter.deployment.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/app","operator":"In","values":["rate-limiter"]}]}}}]}}` | Configure Affinity for the deployment.  |
 | wso2.apk.dp.ratelimiter.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
+| wso2.apk.dp.ratelimiter.deployment.pod.annotations | object | `{}` | Annotations for pods. |
+| wso2.apk.dp.ratelimiter.deployment.pod.labels | object | `{}` | Labels for pods. |
 | wso2.apk.dp.gatewayRuntime.service.annotations | string | `nil` | Gateway service related annotations. |
 | wso2.apk.dp.gatewayRuntime.deployment.replicas | int | `1` | Number of replicas |
 | wso2.apk.dp.gatewayRuntime.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
+| wso2.apk.dp.gatewayRuntime.deployment.pod.annotations | object | `{}` | Annotations for pods. |
+| wso2.apk.dp.gatewayRuntime.deployment.pod.labels | object | `{}` | Labels for pods. |
+| wso2.apk.dp.gatewayRuntime.deployment.extraContainers | list | `[]` | Extra sidecar containers to inject into the gateway runtime pod. |
+| wso2.apk.dp.gatewayRuntime.deployment.extraVolumes | list | `[]` | Extra volumes to add to the gateway runtime pod (used alongside extraContainers). |
 | wso2.apk.dp.gatewayRuntime.deployment.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/app","operator":"In","values":["gateway-runtime"]}]}}}]}}` | Configure Affinity for the deployment.  |
 | wso2.apk.dp.gatewayRuntime.deployment.router.resources.requests.memory | string | `"128Mi"` | CPU request for the container |
 | wso2.apk.dp.gatewayRuntime.deployment.router.resources.requests.cpu | string | `"100m"` | Memory request for the container |
@@ -321,6 +333,9 @@ A Helm chart for Kubernetes Gateway components
 | idp.idpds.deployment.replicas | int | `1` | Number of replicas |
 | idp.idpds.deployment.imagePullPolicy | string | `"Always"` | Image pull policy |
 | idp.idpds.deployment.image | string | `"wso2/apk-idp-domain-service:1.2.0"` | Image |
+| idp.idpds.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
+| idp.idpds.deployment.pod.annotations | object | `{}` | Annotations for pods. |
+| idp.idpds.deployment.pod.labels | object | `{}` | Labels for pods. |
 | idp.idpui.deployment.resources.requests.memory | string | `"128Mi"` | CPU request for the container |
 | idp.idpui.deployment.resources.requests.cpu | string | `"100m"` | Memory request for the container |
 | idp.idpui.deployment.resources.limits.memory | string | `"1028Mi"` | CPU limit for the container |
@@ -335,6 +350,9 @@ A Helm chart for Kubernetes Gateway components
 | idp.idpui.deployment.replicas | int | `1` | Number of replicas |
 | idp.idpui.deployment.imagePullPolicy | string | `"Always"` | Image pull policy |
 | idp.idpui.deployment.image | string | `"wso2/apk-idp-ui:1.2.0"` | Image |
+| idp.idpui.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
+| idp.idpui.deployment.pod.annotations | object | `{}` | Annotations for pods. |
+| idp.idpui.deployment.pod.labels | object | `{}` | Labels for pods. |
 | idp.idpui.configs.idpLoginUrl | string | `"https://idp.am.wso2.com:9095/commonauth/login"` | identity server Login URL |
 | idp.idpui.configs.idpAuthCallBackUrl | string | `"https://idp.am.wso2.com:9095/oauth2/auth-callback"` | identity server authCallBackUrl |
 | gatewaySystem.enabled | bool | `true` | Enable gateway system to install gateway system components |


### PR DESCRIPTION
This pull request updates the Helm chart documentation for Kubernetes Gateway components to add new configuration options for pod-level customization across several components. The main changes introduce support for specifying pod annotations, labels, and node selectors, as well as options for injecting extra containers and volumes in the gateway runtime. These enhancements provide users with greater flexibility to tailor pod behavior and deployment environments.

Key configuration enhancements:

**Pod customization options:**

* Added `pod.annotations` and `pod.labels` fields for the following components, allowing users to specify custom annotations and labels for pods:
  - `wso2.apk.dp.configdeployer`
  - `wso2.apk.dp.adapter`
  - `wso2.apk.dp.commonController`
  - `wso2.apk.dp.ratelimiter`
  - `wso2.apk.dp.gatewayRuntime`
  - `idp.idpds`
  - `idp.idpui`

* Added `nodeSelector` configuration for `idp.idpds` and `idp.idpui` deployments to control node scheduling. [[1]](diffhunk://#diff-66a304fc1c68933ae934dbf5ae4210d882aa7ce54a9538a8168e471ab5a6b75dR336-R338) [[2]](diffhunk://#diff-66a304fc1c68933ae934dbf5ae4210d882aa7ce54a9538a8168e471ab5a6b75dR353-R355)

**Gateway runtime extensibility:**

* Introduced `extraContainers` and `extraVolumes` options in `wso2.apk.dp.gatewayRuntime.deployment`, enabling injection of sidecar containers and additional volumes into the gateway runtime pods.